### PR TITLE
Set schema option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -276,7 +276,9 @@ class Service extends AdapterService {
 
   _createQuery (params = {}) {
     const trx = params.transaction ? params.transaction.trx : null;
-    return this.Model.query(trx);
+    const schema = params.schema || this.options.schema;
+    let query = this.Model.query(trx);
+    return schema ? query.withSchema(schema) : query;
   }
 
   createQuery (params = {}) {


### PR DESCRIPTION
feathers-knex allows the setting of the database schema in the service options.
feathers-objection does not, it always uses the "public" schema (in Postgres).
This change allows that by executing `withScema()` on the query builder.